### PR TITLE
bcmoham-31376: update workflows to fix missing oc cli

### DIFF
--- a/.github/workflows/deploy-rtrans.yml
+++ b/.github/workflows/deploy-rtrans.yml
@@ -57,6 +57,11 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
       # 1. Login to OpenShift
       - name: Log in to OpenShift
         uses: redhat-actions/oc-login@v1
@@ -172,6 +177,11 @@ jobs:
           echo "DEVOPS_DIR=${{needs.compute.outputs.DEVOPS_DIR}}"  | tee -a $GITHUB_ENV
           echo "IMAGE_ID=${{needs.compute.outputs.IMAGE_ID}}"  | tee -a $GITHUB_ENV
 
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
       # Login to OpenShift
       - name: Log in to OpenShift
         uses: redhat-actions/oc-login@v1
@@ -235,6 +245,11 @@ jobs:
           echo "DEPLOY_SUFFIX=${{needs.compute.outputs.DEPLOY_SUFFIX}}"  | tee -a $GITHUB_ENV
           echo "DEVOPS_DIR=${{needs.compute.outputs.DEVOPS_DIR}}"  | tee -a $GITHUB_ENV
           echo "IMAGE_ID=${{needs.compute.outputs.IMAGE_ID}}"  | tee -a $GITHUB_ENV
+
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
 
       # Login to OpenShift
       - name: Log in to OpenShift

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,6 +137,11 @@ jobs:
           echo "IMAGE_TAG=${{steps.get-image-prefix.outputs.result}}-${{github.event.inputs.Build_Run_Number}}"  | tee -a $GITHUB_ENV
           echo "REPLICATE=${{steps.get-replication.outputs.result}}"  | tee -a $GITHUB_ENV
 
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
       # Login to OpenShift
       - name: Log in to OpenShift
         uses: redhat-actions/oc-login@v1
@@ -168,7 +173,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate]
     steps:
-          # Login to Gold OpenShift
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
+      # Login to Gold OpenShift
       - name: Log in to Gold OpenShift
         uses: redhat-actions/oc-login@v1
         with:

--- a/.github/workflows/feature-build.yml
+++ b/.github/workflows/feature-build.yml
@@ -113,6 +113,11 @@ jobs:
     needs: [createRtransFeatureBuild]
     
     steps:
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
       # 1. Login to OpenShift
       - name: Log in to OpenShift
         uses: redhat-actions/oc-login@v1

--- a/.github/workflows/release-rtrans.yml
+++ b/.github/workflows/release-rtrans.yml
@@ -103,6 +103,11 @@ jobs:
         run: |
           echo "This step should move the image to repository to test namespace"
 
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
+
       # Login to OpenShift
       - name: Log in to OpenShift
         uses: redhat-actions/oc-login@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,10 @@ jobs:
     needs: [createRtransRelease]
     
     steps:
+      - name: Install OpenShift CLI
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: latest
 
       # 1. Login to OpenShift
       - name: Log in to OpenShift


### PR DESCRIPTION
Work Item: https://proactionca.ent.cgi.com/jira/browse/BCMOHAM-31376

Updates were made to the workflows to install the oc cli as it is no longer bundled with the runner used for the jobs. Updated workflows were:

- deploy
- deploy-rtrans-esb
- feature-build
- release
- release-rtrans-esb